### PR TITLE
Update iAstroHub_dslr.html

### DIFF
--- a/www/iAstroHub_dslr.html
+++ b/www/iAstroHub_dslr.html
@@ -835,8 +835,10 @@ function refresh() {
 }
 
 function plot() {
-    $.plot(placeholder1, [data1], options);
-    $.plot(placeholder2, [data2], options);
+    	var scroll = document.body.scrollTop;
+	$.plot(placeholder1, [data1], options);
+	$.plot(placeholder2, [data2], options);
+	document.body.scrollTop = scroll;
 }
 
 function IsNumeric(input)


### PR DESCRIPTION
Added two lines in plot() function to store current scroll position and restore it after plotting. This avoids jumping to top of page on every graph update in some browsers.